### PR TITLE
Upgrade shapeless to 2.3.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ scalacOptions in ThisBuild := {
 lazy val typify = crossProject.in(file(".")).
   settings(
     name := "typify",
-    version := "2.4.1",
+    version := "2.5.0",
     libraryDependencies ++= Seq(
       "com.chuusai" %%% "shapeless" % "2.3.3",
       "org.scalaz" %%% "scalaz-core" % "7.2.17",
@@ -70,7 +70,7 @@ lazy val json4sTypify = project.in(file("json4s-typify"))
   .dependsOn(typifyJVM % "test->test;compile->compile")
   .settings(
     name := "json4s-typify",
-    version := "1.4.1",
+    version := "1.5.0",
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
     libraryDependencies ++= Seq(
       "org.json4s" %% "json4s-jackson" % "3.5.3",
@@ -85,7 +85,7 @@ lazy val sjsTypify = project.in(file("jsdynamic-typify"))
   .dependsOn(typifyJS % "test->test;compile->compile")
   .settings(
     name := "jsdynamic-typify",
-    version := "1.4.1",
+    version := "1.5.0",
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
     libraryDependencies ++= Seq(
       "org.scalaz" %%% "scalaz-core" % "7.2.17",
@@ -102,7 +102,7 @@ lazy val playjsonTypify = project.in(file("play-json-typify"))
   .dependsOn(typifyJVM % "test->test;compile->compile")
   .settings(
     name := "play-json-typify",
-    version := "1.4.1",
+    version := "1.5.0",
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-json" % "2.6.6",

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val typify = crossProject.in(file(".")).
     name := "typify",
     version := "2.4.1",
     libraryDependencies ++= Seq(
-      "com.chuusai" %%% "shapeless" % "2.3.2",
+      "com.chuusai" %%% "shapeless" % "2.3.3",
       "org.scalaz" %%% "scalaz-core" % "7.2.17",
       "org.scalacheck" %%% "scalacheck" % "1.12.6" % "test"
     ),

--- a/shared/src/main/scala/Optimize.scala
+++ b/shared/src/main/scala/Optimize.scala
@@ -43,10 +43,10 @@ object Optimize {
 class Optimize[L, P](val tp: Typify[L, P]) {
 
 
-  def folder[G <: HList, R <: HList](in: G)(implicit
-    lf: LeftFolder.Aux[G, tp.PV[HNil], tp.foldPV.type, tp.PV[R]]) = lf
+  def folder[G <: HList, A, R <: HList](in: G)(implicit
+    lf: LeftFolder.Aux[G, tp.PV[HNil], tp.foldPV.type, A], pvEv: A <:< tp.PV[R]) = lf
 
-  def success[G <: HList, R <: HList](in: G)(implicit
-    lf: LeftFolder.Aux[G, tp.PV[HNil], tp.foldPV.type, tp.PV[R]]): TWitness[R] =
+  def success[G <: HList, A, R <: HList](in: G)(implicit
+    lf: LeftFolder.Aux[G, tp.PV[HNil], tp.foldPV.type, A], pvEv: A <:< tp.PV[R]): TWitness[R] =
       new TWitness[R] {}
 }


### PR DESCRIPTION
Adds an extra implicit parameter to `parse` and `parseOption` to fix error from failure to find implicit `LeftFolder`.